### PR TITLE
docker-compose にphpMyAdminコンテナを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,19 @@ services:
     build: ./infra/mysql
     volumes:
       - db-store:/var/lib/mysql
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    depends_on:
+      - db
+    environment:
+      - PMA_ARBITRARY=1
+      - PMA_HOSTS=db
+      - PMA_USER=phper
+      - PMA_PASSWORD=secret
+    ports:
+      - "3000:80"
+    volumes:
+      - ./docker/phpmyadmin/sessions:/sessions
 
 volumes:
   db-store:


### PR DESCRIPTION
# やったこと
docker-compose.ymlファイルにphpMyAdminコンテナを追加し、再度build を行なった。
DBが再度一からの構築となったため、php artisan migrate を行い、phpMyAdminページにてテーブル追加も確認済み。